### PR TITLE
Scale time for frontend date picker

### DIFF
--- a/frontend-config.js
+++ b/frontend-config.js
@@ -122,14 +122,14 @@ const failedReferralView = createTab("Failed Referrals", ":FailedReferral@", [
 const failedCheckInView = createTab("Failed Check-Ins", ":FailedCheckIn@", [
     createIdCol(),
     createCol("patient"),
-    createCol("appointmentDate"),
+    createCol("appointmentTime"),
     createCol("reason", null, 300),
 ]);
 
 const failedSchedulingAppointmentView = createTab("Failed Appointments", ":FailedSchedulingAppointment@", [
     createIdCol(),
     createCol("patient"),
-    createCol("appointmentDate"),
+    createCol("appointmentTime"),
     createCol("reason", null, 300),
 ]);
 

--- a/model/daml/DemoOnboardScenario/Appointment.daml
+++ b/model/daml/DemoOnboardScenario/Appointment.daml
@@ -43,11 +43,11 @@ data PatientAppointmentData4 = PatientAppointmentData4
     appointment4: (ContractId Appointment, ContractId NotifyPayer)
   deriving (Eq, Show)
 
-scheduleAppointment : Party -> ContractId Provider -> ContractId ReferralDetails -> Date ->  Script (ContractId Appointment, ContractId NotifyPayer)
+scheduleAppointment : Party -> ContractId Provider -> ContractId ReferralDetails -> Time ->  Script (ContractId Appointment, ContractId NotifyPayer)
 scheduleAppointment provider providerRole referralDetails appointmentTime  = do
   scheduleResult <- provider `submit` do
     exerciseCmd referralDetails ScheduleAppointment with
-      appointmentDate = appointmentTime
+      appointmentTime = appointmentTime
   return $ fromSome $ eitherToOptional $ scheduleResult
 
 acknowledge : Party -> (ContractId Appointment, ContractId NotifyPayer) -> ContractId InsurancePolicy -> Script (ContractId InsurancePolicy, ContractId NotifyPatient)

--- a/model/daml/DemoOnboardScenario/ReferenceData.daml
+++ b/model/daml/DemoOnboardScenario/ReferenceData.daml
@@ -8,6 +8,7 @@ module DemoOnboardScenario.ReferenceData where
 import Main.Types
 import DA.Next.Map
 import DA.Date
+import DA.Time
 import DA.Optional
 import Daml.Script
 
@@ -132,10 +133,10 @@ patient1Demographics = PatientDemographics
     patientCity = "Columbus"
     patientState = "OH"
     patientZipCode = "43116"
-patient1_appointmentTime1 = date 2018 Jan 1
-patient1_appointmentTime2 = date 2018 Jan 2
-patient1_appointmentTime3 = date 2018 Jan 3
-patient1_appointmentTime4 = date 2018 Jan 4
+patient1_appointmentTime1 = time (date 2018 Jan 1) 10 0 0
+patient1_appointmentTime2 = time (date 2018 Jan 2) 10 0 0
+patient1_appointmentTime3 = time (date 2018 Jan 3) 10 0 0
+patient1_appointmentTime4 = time (date 2018 Jan 4) 10 0 0
 -- Patient2
 patient2_Name = "Jim Smith"
 patient2_InsuranceId = "GDR-53-7245"
@@ -150,9 +151,9 @@ patient2Demographics = PatientDemographics
     patientCity = "Columbus"
     patientState = "OH"
     patientZipCode = "43002"
-patient2_appointmentTime1 = date 2018 Feb 1
-patient2_appointmentTime2 = date 2018 Feb 2
-patient2_appointmentTime3 = date 2018 Feb 3
+patient2_appointmentTime1 = time (date 2018 Feb 1) 10 0 0
+patient2_appointmentTime2 = time (date 2018 Feb 2) 10 0 0
+patient2_appointmentTime3 = time (date 2018 Feb 3) 10 0 0
 -- Patient3
 patient3_Name = "Sally Smith"
 patient3_InsuranceId = "QEW-22-9999"
@@ -167,9 +168,9 @@ patient3Demographics = PatientDemographics
     patientCity = "Columbus"
     patientState = "OH"
     patientZipCode = "43090"
-patient3_appointmentTime1 = date 2018 Mar 1
-patient3_appointmentTime2 = date 2018 Mar 2
-patient3_appointmentTime3 = date 2018 Mar 3
+patient3_appointmentTime1 = time (date 2018 Mar 1) 10 0 0
+patient3_appointmentTime2 = time (date 2018 Mar 2) 10 0 0
+patient3_appointmentTime3 = time (date 2018 Mar 3) 10 0 0
 -- Patient4
 patient4_Name = "Kim Chao"
 patient4_InsuranceId = "LKV-65-3434"
@@ -184,9 +185,9 @@ patient4Demographics = PatientDemographics
     patientCity = "Columbus"
     patientState = "OH"
     patientZipCode = "43221"
-patient4_appointmentTime1 = date 2018 Apr 1
-patient4_appointmentTime2 = date 2018 Apr 2
-patient4_appointmentTime3 = date 2018 Apr 3
+patient4_appointmentTime1 = time (date 2018 Apr 1) 10 0 0
+patient4_appointmentTime2 = time (date 2018 Apr 2) 10 0 0
+patient4_appointmentTime3 = time (date 2018 Apr 3) 10 0 0
 -- Patient5
 patient5_Name = "Ted Walker"
 patient5_InsuranceId = "NVU-12-1345"
@@ -201,9 +202,9 @@ patient5Demographics = PatientDemographics
     patientCity = "Columbus"
     patientState = "OH"
     patientZipCode = "43019"
-patient5_appointmentTime1 = date 2018 May 1
-patient5_appointmentTime2 = date 2018 May 2
-patient5_appointmentTime3 = date 2018 May 3
+patient5_appointmentTime1 = time (date 2018 May 1) 10 0 0
+patient5_appointmentTime2 = time (date 2018 May 2) 10 0 0
+patient5_appointmentTime3 = time (date 2018 May 3) 10 0 0
 -- Patient6
 patient6_Name = "Richard Jones"
 patient6_InsuranceId = "PLK-90-9090"
@@ -218,9 +219,9 @@ patient6Demographics = PatientDemographics
     patientCity = "Columbus"
     patientState = "OH"
     patientZipCode = "43189"
-patient6_appointmentTime1 = date 2018 Jun 1
-patient6_appointmentTime2 = date 2018 Jun 2
-patient6_appointmentTime3 = date 2018 Jun 3
+patient6_appointmentTime1 = time (date 2018 Jun 1) 10 0 0
+patient6_appointmentTime2 = time (date 2018 Jun 2) 10 0 0
+patient6_appointmentTime3 = time (date 2018 Jun 3) 10 0 0
 -- Patient7
 patient7_Name = "Kate Andrews"
 patient7_InsuranceId = "ZRX-34-3456"
@@ -235,9 +236,9 @@ patient7Demographics = PatientDemographics
     patientCity = "Columbus"
     patientState = "OH"
     patientZipCode = "43165"
-patient7_appointmentTime1 = date 2018 Jul 1
-patient7_appointmentTime2 = date 2018 Jul 2
-patient7_appointmentTime3 = date 2018 Jul 3
+patient7_appointmentTime1 = time (date 2018 Jul 1) 10 0 0
+patient7_appointmentTime2 = time (date 2018 Jul 2) 10 0 0
+patient7_appointmentTime3 = time (date 2018 Jul 3) 10 0 0
 -- Patient8
 patient8_Name = "Bill Richards"
 patient8_InsuranceId = "ADT-34-3256"

--- a/model/daml/DemoOnboardScenario/Treatment.daml
+++ b/model/daml/DemoOnboardScenario/Treatment.daml
@@ -8,7 +8,6 @@ module DemoOnboardScenario.Treatment where
 
 import DA.Either
 import DA.Optional
-import DA.Time
 
 import Daml.Script
 
@@ -54,65 +53,65 @@ treatmentTest parties@Parties{..} = script
     let
       rp1: RuleParameters = appt.referral.patient1.ruleParams1
 
-    setTime (time patient1_appointmentTime1 0 0 0)
+    setTime patient1_appointmentTime1
     treatmentCid11 <- checkIn provider2 (appt.patient1.appointment1)
     paymentReq11 <- completeTreatment provider2 treatmentCid11
 
-    setTime (time patient1_appointmentTime2 0 0 0)
+    setTime patient1_appointmentTime2
     treatmentCid12 <- checkIn provider1 (appt.patient1.appointment2)
     paymentReq12 <- completeTreatment provider1 treatmentCid12
 
-    setTime (time patient2_appointmentTime1 0 0 0)
+    setTime patient2_appointmentTime1
     treatmentCid21 <- checkIn provider2 (appt.patient2.appointment1)
     paymentReq21 <- completeTreatment provider2 treatmentCid21
 
-    setTime (time patient2_appointmentTime2 0 0 0)
+    setTime patient2_appointmentTime2
     treatmentCid22 <- checkIn provider1 (appt.patient2.appointment2)
     paymentReq22 <- completeTreatment provider1 treatmentCid22
 
-    setTime (time patient2_appointmentTime3 0 0 0)
+    setTime patient2_appointmentTime3
     treatmentCid23 <- checkIn provider2 (appt.patient2.appointment3)
     paymentReq23 <- completeTreatment provider2 treatmentCid23
 
-    setTime (time patient3_appointmentTime1 0 0 0)
+    setTime patient3_appointmentTime1
     _treatmentCid31 <- checkIn provider2 (appt.patient3.appointment1)
 
-    setTime (time patient3_appointmentTime2 0 0 0)
+    setTime patient3_appointmentTime2
     treatmentCid32 <- checkIn provider1 (appt.patient3.appointment2)
     paymentReq32 <- completeTreatment provider1 treatmentCid32
 
-    setTime (time patient3_appointmentTime3 0 0 0)
+    setTime patient3_appointmentTime3
     treatmentCid33 <- checkIn provider2 (appt.patient3.appointment3)
     paymentReq33 <- completeTreatment provider2 treatmentCid33
 
-    setTime (time patient4_appointmentTime2 0 0 0)
+    setTime patient4_appointmentTime2
     treatmentCid42 <- checkIn provider1 (appt.patient4.appointment2)
     paymentReq42 <- completeTreatment provider1 treatmentCid42
 
-    setTime (time patient5_appointmentTime2 0 0 0)
+    setTime patient5_appointmentTime2
     treatmentCid52 <- checkIn provider1 (appt.patient5.appointment2)
     paymentReq52 <- completeTreatment provider1 treatmentCid52
 
-    setTime (time patient5_appointmentTime3 0 0 0)
+    setTime patient5_appointmentTime3
     _treatmentCid53 <- checkIn provider2 (appt.patient5.appointment3)
     -- the corresponding payment request can be created within the application
 
-    setTime (time patient6_appointmentTime2 0 0 0)
+    setTime patient6_appointmentTime2
     treatmentCid62 <- checkIn provider1 (appt.patient6.appointment2)
     paymentReq62 <- completeTreatment provider1 treatmentCid62
 
-    setTime (time patient6_appointmentTime3 0 0 0)
+    setTime patient6_appointmentTime3
     treatmentCid63 <- checkIn provider2 (appt.patient6.appointment3)
     paymentReq63 <- completeTreatment provider2 treatmentCid63
 
-    setTime (time patient7_appointmentTime1 0 0 0)
+    setTime patient7_appointmentTime1
     treatmentCid71 <- checkIn provider2 (appt.patient7.appointment1)
     paymentReq71 <- completeTreatment provider2 treatmentCid71
 
-    setTime (time patient7_appointmentTime2 0 0 0)
+    setTime patient7_appointmentTime2
     _treatmentCid72 <- checkIn provider1 (appt.patient7.appointment2)
 
-    setTime (time patient7_appointmentTime3 0 0 0)
+    setTime patient7_appointmentTime3
     _treatmentCid73 <- checkIn provider2 (appt.patient7.appointment3)
 
     return $ TreatmentData appt paymentReq11 paymentReq12 paymentReq21 paymentReq22 paymentReq23 paymentReq32 paymentReq33 paymentReq42 paymentReq52 paymentReq62 paymentReq63 paymentReq71

--- a/model/daml/Main/Appointment.daml
+++ b/model/daml/Main/Appointment.daml
@@ -8,7 +8,7 @@
 
 module Main.Appointment where
 
-import DA.Date
+import DA.Time
 
 import Main.Treatment
 import Main.Types()
@@ -25,7 +25,7 @@ template Appointment
     patient : Party
     policy : ContractId DisclosedPolicy
     encounterDetails : RuleParameters
-    appointmentDate: Date
+    appointmentTime : Time
   where
     signatory provider
     observer patient
@@ -35,8 +35,9 @@ template Appointment
       CheckInPatient : Either (ContractId FailedCheckIn) (ContractId Treatment)
         do
           now <- getTime
-          let today = toDateUTC now
-          assertMsg ("Check-in should happen on appointment date: " <> show appointmentDate) $ appointmentDate == today
+          let diff = appointmentTime `subTime` now
+          assertMsg ("Check-in should happen on appointment date: " <> show appointmentTime) $
+            diff >= minutes 0 && diff < minutes 2
           rulesCheck <- create RulesCheck with
             requestingParty = provider
             ruleParams = encounterDetails
@@ -62,7 +63,7 @@ template FailedCheckIn
     operator : Party
     provider : Party
     patient: Party
-    appointmentDate: Date
+    appointmentTime: Time
     reason : Text
   where
     signatory provider

--- a/model/daml/Main/Provider.daml
+++ b/model/daml/Main/Provider.daml
@@ -213,7 +213,7 @@ template ReferralDetails
 
       nonconsuming ScheduleAppointment : Either (ContractId FailedSchedulingAppointment) (ContractId Appointment, ContractId NotifyPayer)
         with
-          appointmentDate : Date
+          appointmentTime : Time
         do
           rulesCheck <- create RulesCheck with
             requestingParty = renderingProvider
@@ -248,7 +248,7 @@ template FailedSchedulingAppointment
     operator : Party
     provider : Party
     patient: Party
-    appointmentDate: Date
+    appointmentTime: Time
     reason : Text
   where
     signatory provider

--- a/model/daml/Test/Appointment.daml
+++ b/model/daml/Test/Appointment.daml
@@ -23,7 +23,7 @@ data AppointmentScenarioOutput =
     appointmentCid : (ContractId Appointment, ContractId NotifyPayer)
     appointmentDetails : RuleParameters
     originalPolicy : ContractId InsurancePolicy
-    appointmentDate: Date
+    appointmentTime: Time
 
 -- standalone version to view it in DAML Studio
 appointmentTest' = appointmentTest =<< allocateParties
@@ -41,7 +41,7 @@ appointmentTest parties@Parties{..} = script
 
     scheduleResult <- provider2 `submit` do
       exerciseCmd referralDetails ScheduleAppointment with
-        appointmentDate = patient1_appointmentTime
+        appointmentTime = patient1_appointmentTime
     let appointmentCid = fromSome $ eitherToOptional $ scheduleResult
 
     (updatedPolicy, notifyPatient) <- payer1 `submit`
@@ -58,4 +58,4 @@ appointmentTest parties@Parties{..} = script
     return AppointmentScenarioOutput with
       appointmentDetails = updatedApptDetails
       originalPolicy = updatedPolicy
-      appointmentDate = patient1_appointmentTime, ..
+      appointmentTime = patient1_appointmentTime, ..

--- a/model/daml/Test/ReferenceData.daml
+++ b/model/daml/Test/ReferenceData.daml
@@ -8,6 +8,7 @@ module Test.ReferenceData where
 import Main.Types
 import DA.Next.Map
 import DA.Date
+import DA.Time
 import DA.Optional
 
 -- InsuranceCompany
@@ -33,7 +34,7 @@ patient1_Address = "1234 John St."
 patient1_diagnosisCode = "ABCDE"
 patient1_procedureCode = "12345"
 patient1_globalEncounterId = "1010101010"
-patient1_appointmentTime = date 2018 Dec 31
+patient1_appointmentTime = time (date 2018 Dec 31) 16 0 0
 patient1_AddressLine2 = ""
 patient1_City = "Cincinnati"
 patient1_State = "OH"

--- a/model/daml/Test/Treatment.daml
+++ b/model/daml/Test/Treatment.daml
@@ -6,7 +6,6 @@
 
 module Test.Treatment where
 
-import DA.Time
 import DA.Either
 import DA.Optional
 import Main.Appointment
@@ -30,7 +29,7 @@ treatmentTest' = treatmentTest =<< allocateParties
 treatmentTest parties@Parties{..} = script do
     apptScenario <- appointmentTest parties
 
-    setTime (time apptScenario.appointmentDate 0 0 0)
+    setTime apptScenario.appointmentTime
 
     let
       provider2Role = apptScenario.provider2Role

--- a/src/test/java/com/digitalasset/refapps/healthcareclaims/HealthcareClaimsProcessingIT.java
+++ b/src/test/java/com/digitalasset/refapps/healthcareclaims/HealthcareClaimsProcessingIT.java
@@ -122,16 +122,16 @@ public class HealthcareClaimsProcessingIT {
         ledgerAdapter.getCreatedContractId(
             RADIOLOGIST_PARTY, ReferralDetails.TEMPLATE_ID, ReferralDetails.ContractId::new);
 
-    LocalDate appointmentDate = LocalDate.of(2019, 7, 7);
+    LocalDate appointmentTime = LocalDate.of(2019, 7, 7);
     sandbox
         .getLedgerAdapter()
         .exerciseChoice(
-            RADIOLOGIST_PARTY, updatedReferral.exerciseScheduleAppointment(appointmentDate));
+            RADIOLOGIST_PARTY, updatedReferral.exerciseScheduleAppointment(appointmentTime));
 
     // Check-in should happen on appointment date
     sandbox
         .getLedgerAdapter()
-        .setCurrentTime(Instant.ofEpochSecond(appointmentDate.toEpochDay() * 24 * 60 * 60));
+        .setCurrentTime(Instant.ofEpochSecond(appointmentTime.toEpochDay() * 24 * 60 * 60));
     Appointment.ContractId appointment =
         ledgerAdapter.getCreatedContractId(
             RADIOLOGIST_PARTY, Appointment.TEMPLATE_ID, Appointment.ContractId::new);
@@ -192,11 +192,11 @@ public class HealthcareClaimsProcessingIT {
         ledgerAdapter.getCreatedContractId(
             RADIOLOGIST_PARTY, ReferralDetails.TEMPLATE_ID, ReferralDetails.ContractId::new);
 
-    LocalDate appointmentDate = LocalDate.of(2019, 7, 7);
+    LocalDate appointmentTime = LocalDate.of(2019, 7, 7);
     sandbox
         .getLedgerAdapter()
         .exerciseChoice(
-            RADIOLOGIST_PARTY, updatedReferral.exerciseScheduleAppointment(appointmentDate));
+            RADIOLOGIST_PARTY, updatedReferral.exerciseScheduleAppointment(appointmentTime));
 
     // Check-in should happen on appointment date!
     Appointment.ContractId appointment =

--- a/triggers/daml/Test/Triggers/AcknowledgeAppointmentTriggerTest.daml
+++ b/triggers/daml/Test/Triggers/AcknowledgeAppointmentTriggerTest.daml
@@ -70,7 +70,7 @@ appointmentTest parties@Parties{..} = script do
 
   scheduleResult <- provider2 `submit` do
     exerciseCmd referralDetails ScheduleAppointment with
-      appointmentDate = patient1_appointmentTime
+      appointmentTime = patient1_appointmentTime
   let appointmentCid = fromSome $ eitherToOptional $ scheduleResult
 
   pure (originalPolicy, snd appointmentCid)

--- a/triggers/daml/Triggers/AcknowledgeAndDiscloseTrigger.daml
+++ b/triggers/daml/Triggers/AcknowledgeAndDiscloseTrigger.daml
@@ -123,7 +123,7 @@ appointmentTest parties@Parties{..} = script do
 
   scheduleResult <- provider2 `submit`
     Script.exerciseCmd referralDetails ScheduleAppointment with
-      appointmentDate = patient1_appointmentTime
+      appointmentTime = patient1_appointmentTime
   let appointmentCid = fromSome $ eitherToOptional scheduleResult
 
   (updatePolicy, notifyPatient) <- payer1 `submit`

--- a/ui/src/components/Appointments.tsx
+++ b/ui/src/components/Appointments.tsx
@@ -36,7 +36,7 @@ const Appointments: React.FC = () => {
     title="Appointments"
     useData={useAppointmentsData}
     fields={ [
-      { label: "Appointment Date", getter: o => o?.appointment?.payload?.appointmentDate },
+      { label: "Appointment Date", getter: o => o?.appointment?.payload?.appointmentTime },
       { label: "Patient Name", getter: o => o?.policy?.payload?.patientName },
       { label: "Insurance ID", getter: o => o?.policy?.payload?.insuranceID },
       { label: "Procedure Code", getter: o => o?.appointment?.payload?.encounterDetails.encounterDetails.procedureCode },
@@ -59,7 +59,7 @@ const Appointment : React.FC = () => {
     useData={useAppointmentData}
     fields={ [[
       { label: "Patient Name", getter: o => o?.overview?.policy?.payload?.patientName },
-      { label: "Appointment Date", getter: o => o?.overview?.appointment?.payload?.appointmentDate },
+      { label: "Appointment Date", getter: o => o?.overview?.appointment?.payload?.appointmentTime },
       { label: "Appointment Priority", getter: o => o?.overview?.appointment?.payload?.encounterDetails.encounterDetails.appointmentPriority },
       { label: "Procedure Code", getter: o => o?.overview?.appointment?.payload?.encounterDetails.encounterDetails.procedureCode },
       { label: "Diagnosis Code", getter: o => o?.overview?.appointment?.payload?.encounterDetails.encounterDetails.diagnosisCode },

--- a/ui/src/components/ChoiceModal.tsx
+++ b/ui/src/components/ChoiceModal.tsx
@@ -224,14 +224,26 @@ export const DayPickerField : React.FC<{
 }> = ({ name, errors }) => {
   const [ field, meta, { setValue } ] = useField<string | Nothing>(name);
   const error = errors?.[name];
+  const DAY_VS_MIN = 1440;
+  const daysToMin = (d: Date) => {
+    const ret = new Date();
+    ret.setTime(d.getTime() / DAY_VS_MIN);
+    return ret;
+  };
+  const minToDays = (d: Date) => {
+    const ret = new Date();
+    ret.setTime(d.getTime() * DAY_VS_MIN);
+    return ret;
+  };
   return (
     <>
       <DayPicker
-        date={field.value == Nothing
+        date={minToDays(
+          field.value == Nothing
             ? new Date()
-            : new Date(field.value + "T00:10:00")
-        }
-        setDate={(d)=>setValue(d.toISOString().split('T')[0])}
+            : new Date(field.value)
+        )}
+        setDate={(d)=>setValue(daysToMin(d).toISOString())}
         theme={({ blue: "var(--blue)" })}
       />
       <RenderError error={error} />

--- a/ui/src/components/Referrals.tsx
+++ b/ui/src/components/Referrals.tsx
@@ -71,7 +71,7 @@ const Referral: React.FC = () => {
                          submitTitle="Schedule Appointment"
                          buttonTitle="Schedule Appointment"
                          icon={<Share />}
-                         initialValues={ { appointmentDate: Nothing } }
+                         initialValues={ { appointmentTime: Nothing } }
                          successWidget={({ rv: [v, evts] }, close) =>
                            <>
                              <Message
@@ -84,7 +84,7 @@ const Referral: React.FC = () => {
             >
               <h1 className="text-center">Schedule Appointment</h1>
               <p>Select a date for this appointment</p>
-              <DayPickerField name="appointmentDate" />
+              <DayPickerField name="appointmentTime" />
             </ChoiceModal>
     ] }
 


### PR DESCRIPTION
1 day = 1 minute; the backend allows a 2 minute window for checking appointments ("patient can be up to 100% late"). This will allow testing check-in success failure workflows without restarting the backend to fake different times.