### PR TITLE
ChoiceModal: re-enable submit button on failure

### DIFF
--- a/ui/src/components/ChoiceModal.tsx
+++ b/ui/src/components/ChoiceModal.tsx
@@ -94,6 +94,9 @@ export function ChoiceModal<T extends object, C, R, K>({ choice, contract, submi
         ledger.exercise(choice, contract, arg).then(success, failure);
     } else {
         console.log("Incomplete Parameters");
+        // unless we do this then the "isSubmitting" property will be "true",
+        //  which results in the Submit button being disabled.
+        setSubmitting(false);
     }
   };
   var content;


### PR DESCRIPTION
Before, when verification failed (`complete(values)` equals `undefined`), the submit button would keep being disabled. This is because `isSubmitting` continues to be `true` unless `setSubmitting(false)` is called.
Note that the submit button is always disabled just after it's pressed (presumably to prevent submitting twice), but should be enabled again in case of failure.