### PR TITLE
Appointment: use proper date formatting

### DIFF
--- a/ui/src/components/Appointments.tsx
+++ b/ui/src/components/Appointments.tsx
@@ -4,16 +4,18 @@ import { Main } from '@daml.js/healthcare-claims-processing';
 import { CreateEvent } from '@daml/ledger';
 import { useStreamQuery, useLedger } from '@daml/react';
 import { CaretRight, Clock, ArrowRight } from "phosphor-react";
-import { mapIter, innerJoin, intercalate, Field, FieldsRow, Message, TabLink, useAsync } from "./Common";
+import { mapIter, innerJoin, intercalate, Field, FieldsRow, Message, TabLink, useAsync, formatDate } from "./Common";
 import { Formik, Form, Field as FField, useField } from 'formik';
 import Select from 'react-select';
 import { LField, EField, ChoiceModal, FollowUp, Nothing, creations } from "./ChoiceModal";
 import { TabularScreenRoutes, TabularView, SingleItemView } from "./TabularScreen";
-import { Party } from '@daml/types';
+import { Party, Time } from '@daml/types';
 
 type Props = {
   role: Party;
 }
+
+const formatDateHelper = (timeStr : Time) => timeStr ? formatDate(new Date(timeStr)) : "";
 
 const AppointmentRoutes : React.FC<Props> = ({role}) =>
   <TabularScreenRoutes metavar=":appointmentId" table={Appointments} detail={Appointment({role})}/>
@@ -41,7 +43,7 @@ const Appointments: React.FC = () => {
     title="Appointments"
     useData={useAppointmentsData}
     fields={ [
-      { label: "Appointment Date", getter: o => o?.appointment?.payload?.appointmentTime },
+      { label: "Appointment Date", getter: o => formatDateHelper(o?.appointment?.payload?.appointmentTime) },
       { label: "Patient Name", getter: o => o?.policy?.payload?.patientName },
       { label: "Insurance ID", getter: o => o?.policy?.payload?.insuranceID },
       { label: "Procedure Code", getter: o => o?.appointment?.payload?.encounterDetails.encounterDetails.procedureCode },
@@ -64,7 +66,7 @@ const Appointment : React.FC<Props> = ({role}) => {
     useData={useAppointmentData}
     fields={ [[
       { label: "Patient Name", getter: o => o?.overview?.policy?.payload?.patientName },
-      { label: "Appointment Date", getter: o => o?.overview?.appointment?.payload?.appointmentTime },
+      { label: "Appointment Date", getter: o => formatDateHelper(o?.overview?.appointment?.payload?.appointmentTime) },
       { label: "Appointment Priority", getter: o => o?.overview?.appointment?.payload?.encounterDetails.encounterDetails.appointmentPriority },
       { label: "Procedure Code", getter: o => o?.overview?.appointment?.payload?.encounterDetails.encounterDetails.procedureCode },
       { label: "Diagnosis Code", getter: o => o?.overview?.appointment?.payload?.encounterDetails.encounterDetails.diagnosisCode },

--- a/ui/src/components/Common.tsx
+++ b/ui/src/components/Common.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react'
 import { NavLink, Route, Switch, useRouteMatch, useParams } from 'react-router-dom';
+import dateFormat from 'dateformat';
 
 type FieldProps = {label: string, value: string};
 
@@ -33,6 +34,8 @@ function innerJoin<K, X, Y>(xs: Map<K, X>, ys: Map<K, Y>): Map<K, [X, Y]> {
   }
   return ret;
 }
+
+export const formatDate = (d:Date) => dateFormat(d, "ddd, mmm d, yyyy");
 
 const TabLink: React.FC<{to:string}> = ({children,to}) => {
   const match = useRouteMatch();

--- a/ui/src/components/MainScreen.tsx
+++ b/ui/src/components/MainScreen.tsx
@@ -3,7 +3,6 @@
 
 import React from 'react'
 import { Image, Menu } from 'semantic-ui-react'
-import dateFormat from 'dateformat';
 import DayPicker from './DayPicker'
 import FormikMod, { Formik, Form, Field, FieldProps, FormikHelpers, FieldAttributes, useField } from 'formik';
 import { SubmitButton, DayPickerField, Nothing } from "./ChoiceModal";
@@ -13,6 +12,7 @@ import { useParty } from '@daml/react';
 import { Link, Route } from 'react-router-dom';
 import { TabularScreenRoutes } from './TabularScreen';
 import '@fontsource/alata';
+import { formatDate } from './Common';
 
 type Props = {
   onLogout: () => void;
@@ -79,7 +79,6 @@ const sidebar: Map<string, Array<TabProps>> = new Map([
 const MainScreen: React.FC<Props> = ({onLogout}) => {
   const [modalActive,setModalActive] = React.useState(false);
   const [date, setDate] = React.useState(new Date());
-  const formatDate = (d:Date) => dateFormat(d, "ddd, mmm d, yyyy");
   const role = useParty();
   const theme = {
     blue: '#4c6fea',


### PR DESCRIPTION
Before, an ISO date string was displayed (e.g. "2021-02-10T05:08:27.547012Z").

Also: move "formatDate" helper function into Common