### PR TITLE
Circle CI: build/test/lint UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,36 @@ commands:
           fail_only: true
           only_for_branches: main
           webhook: '${SLACK_WEBHOOK}'
+  install_yq:
+    description: "Install yq"
+    steps:
+      - run:
+          name: Install pipenv
+          command: |
+            sudo apt-get update || sudo apt-get update
+            sudo apt-get install python3-pip
+            pip3 install pipenv
+      - run:
+          name: Install yq
+          command: |
+            pip3 install yq
+  install_prerequisites:
+    description: "Install all prerequisites"
+    parameters:
+      daml_sdk_version:
+        type: string
+    steps:
+      - install_sdk:
+          version: << parameters.daml_sdk_version >>
+      - install_yq
+      - update_npm
+  update_npm:
+    description: "Upgrade npm to v7"
+    steps:
+      - run:
+          name: install npm v7
+          command: |
+            sudo npm install -g npm@7.13.0
 
 jobs:
   daml_test:
@@ -158,6 +188,38 @@ jobs:
             - "NOTICE"
       - slack_notification
 
+  ui_test:
+    parameters:
+      daml_sdk_version:
+        type: string
+    executor: daml-executor
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - node-v1-{{ .Branch }}-{{ checksum "ui/package-lock.json" }}
+            - node-v1-{{ .Branch }}-
+            - node-v1-
+      - install_prerequisites:
+          daml_sdk_version: << parameters.daml_sdk_version >>
+      - run:
+          name: UI install dependencies
+          command: |
+            make build -j3
+      - run:
+          name: UI build
+          command: |
+            make daml-hub-package LEDGER_ID=some_ledger_id
+      - run:
+          name: Npm test
+          command: |
+            make -C ui test
+      - save_cache:
+          paths:
+            - ui/node_modules
+          key: node-v1-{{ .Branch }}-{{ checksum "ui/package-lock.json" }}
+      - slack_notification
+
 workflows:
   version: 2
   test:
@@ -168,6 +230,8 @@ workflows:
       - integration_test:
           daml_sdk_version: "1.12.0"
           context: refapps
+      - ui_test:
+          daml_sdk_version: "1.13.1"
   scheduled_test:
     triggers:
       - schedule:

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,21 @@ build: build-dars ui/daml.js
 clean:
 	rm -rf model/.daml triggers/.daml
 	rm -rf target
+	rm -rf ui/daml.js
+	$(MAKE) clean -C ui
 
 ui/daml.js: build-dars
 	rm -rf ui/daml.js
 	daml codegen js target/healthcare-claims-processing.dar -o ui/daml.js
+
+build-ui: ui/daml.js
+	$(MAKE) -C ui
+
+test-ui: build-ui
+	$(MAKE) -C ui test
+
+daml-hub-package: build
+	$(MAKE) -C ui daml-hub-package LEDGER_ID=$(LEDGER_ID)
 
 ### DARS ###
 

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+build: npminstall
+
+test: build eslint
+	npm test -- --watchAll=false
+
+clean:
+	rm -rf node_modules
+	rm -f healthcare-claims-processing-ui.zip
+	rm -rf build
+
+JS_CODEGEN_ARTIFACT=daml.js/healthcare-claims-processing-2.0.0/package.json
+
+UI_INSTALL_ARTIFACT=node_modules
+
+npminstall: $(UI_INSTALL_ARTIFACT)
+
+package-lock.json: package.json
+	npm install
+
+$(UI_INSTALL_ARTIFACT): package.json package-lock.json $(JS_CODEGEN_ARTIFACT)
+	npm install
+	touch $(UI_INSTALL_ARTIFACT)
+
+eslint: npminstall
+	npm run-script lint -- --max-warnings 0
+
+daml-hub-package: healthcare-claims-processing-ui.zip
+
+UI_SRC=$(shell find src/ -type f)
+
+healthcare-claims-processing-ui.zip: $(UI_INSTALL_ARTIFACT) $(UI_SRC)
+	REACT_APP_LEDGER_ID=$(LEDGER_ID) \
+	REACT_APP_HTTP_BASE_URL="https://api.projectdabl.com/data/$(LEDGER_ID)/" \
+	REACT_APP_IS_LOCAL=false \
+	npm run build
+	rm -f healthcare-claims-processing-ui.zip
+	zip --quiet -r healthcare-claims-processing-ui.zip build


### PR DESCRIPTION
Note: `ui_test` is currently failing because `npm run-script lint` reports a total of 211 warnings. Also, `daml_test` and `integration_test` are failing because the "refapps" context is missing. We should be able to remove this context without issues. I think these two issues should be fixed in a separate PR.