### PR TITLE
Fix "react-hooks/exhaustive-deps" linter warning

### DIFF
--- a/ui/src/components/Appointments.tsx
+++ b/ui/src/components/Appointments.tsx
@@ -20,7 +20,7 @@ const AppointmentRoutes : React.FC<Props> = ({role}) =>
 
 const useAppointments = (query: any) => {
   const ledger = useLedger();
-  const appointment = useAsync(async () => query.appointmentId ? await ledger.fetch(Main.Appointment.Appointment, query.appointmentId) : null, [query]);
+  const appointment = useAsync(async () => query.appointmentId ? await ledger.fetch(Main.Appointment.Appointment, query.appointmentId) : null, query);
   const appointmentsStream = useStreamQuery(Main.Appointment.Appointment, () => query).contracts;
   const appointments : readonly CreateEvent<Main.Appointment.Appointment>[] = query.appointmentId && appointment ? [appointment] : appointmentsStream;
 

--- a/ui/src/components/Bills.tsx
+++ b/ui/src/components/Bills.tsx
@@ -13,7 +13,7 @@ const BillRoutes : React.FC = () =>
 
 const useBills = (query: any) => {
   const ledger = useLedger();
-  const bill = useAsync(async () => query.billId ? await ledger.fetch(Main.Claim.PatientObligation, query.billId) : null, [query]);
+  const bill = useAsync(async () => query.billId ? await ledger.fetch(Main.Claim.PatientObligation, query.billId) : null, query);
   const billsStream = useStreamQuery(Main.Claim.PatientObligation, () => query).contracts;
   const bills : readonly CreateEvent<Main.Claim.PatientObligation>[] = query.billId && bill ? [bill] : billsStream;
   const receipts = useStreamQuery(Main.Claim.PaymentReceipt, () => ({ })).contracts;

--- a/ui/src/components/Claims.tsx
+++ b/ui/src/components/Claims.tsx
@@ -18,7 +18,7 @@ const ClaimRoutes : React.FC<Props> = ({role}) =>
 
 const useClaims = (query: any) => {
   const ledger = useLedger();
-  const claim = useAsync(async () => query.claimId ? await ledger.fetch(Main.Claim.Claim, query.claimId) : null, [query]);
+  const claim = useAsync(async () => query.claimId ? await ledger.fetch(Main.Claim.Claim, query.claimId) : null, query);
   const claimsStream = useStreamQuery(Main.Claim.Claim, () => query).contracts;
   const claims : readonly CreateEvent<Main.Claim.Claim>[] = query.claimId && claim ? [claim] : claimsStream;
   const receipts = useStreamQuery(Main.Claim.PaymentReceipt, () => ({ })).contracts;

--- a/ui/src/components/Common.tsx
+++ b/ui/src/components/Common.tsx
@@ -114,12 +114,15 @@ const Message: React.FC<{title: string, content: string}> = ({title, content}) =
   )
 }
 
-function useAsync<T>(f: () => Promise<T>, memoKeys: [any]) : T | null {
+// Requirement: do not pass an array as "memoKeys" argument,
+//  since it's assumed that "useMemo" doesn't look at the content
+//  of arrays.
+function useAsync<T>(f: () => Promise<T>, memoKeys: any) : T | null {
   const [[v, lastMemoKeys], setV] = useState<[T | null, any]>([null, null]);
   useMemo(
     // some false positives so we do the extra comparison to avoid extra `setV`
     () => { if(JSON.stringify(memoKeys) !== JSON.stringify(lastMemoKeys)) { f().then(nv => setV([nv, memoKeys])) } },
-    memoKeys);
+    [f, memoKeys, lastMemoKeys]);
   return v;
 }
 

--- a/ui/src/components/Referrals.tsx
+++ b/ui/src/components/Referrals.tsx
@@ -18,7 +18,7 @@ const ReferralRoutes : React.FC<Props> = ({role}) =>
 
 const useReferrals = (query: any) => {
   const ledger = useLedger();
-  const referral = useAsync(async () => query.referralId ? await ledger.fetch(Main.Provider.ReferralDetails, query.referralId) : null, [query]);
+  const referral = useAsync(async () => query.referralId ? await ledger.fetch(Main.Provider.ReferralDetails, query.referralId) : null, query);
   const referralsStream = useStreamQuery(Main.Provider.ReferralDetails, () => query).contracts;
   const referrals : readonly CreateEvent<Main.Provider.ReferralDetails>[] = query.referralId && referral ? [referral] : referralsStream;
 

--- a/ui/src/components/Treatments.tsx
+++ b/ui/src/components/Treatments.tsx
@@ -14,7 +14,7 @@ const TreatmentRoutes : React.FC<{role: Party}> = ({role}) =>
 
 const useTreatments = (query: any) => {
   const ledger = useLedger();
-  const treatment = useAsync(async () => query.treatmentId ? await ledger.fetch(Main.Treatment.Treatment, query.treatmentId) : null, [query]);
+  const treatment = useAsync(async () => query.treatmentId ? await ledger.fetch(Main.Treatment.Treatment, query.treatmentId) : null, query);
   const treatmentsStream = useStreamQuery(Main.Treatment.Treatment, () => query).contracts;
   const treatments : readonly CreateEvent<Main.Treatment.Treatment>[] = query.treatmentId && treatment ? [treatment] : treatmentsStream;
 


### PR DESCRIPTION
NB: we change the second argument of "useAsync" to not be an array, since it is assumed that "useMemo" doesn't look at the content of arrays

Fixes "ui_test" in CI \o/

Thank you @jonored for helping with this